### PR TITLE
manifests/repository.pp: Linting: Remove trailing whitespace

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -5,7 +5,7 @@ class graylog::repository(
 ) inherits graylog::params {
   anchor { 'graylog::repository::begin': }
   anchor { 'graylog::repository::end': }
-  
+
   if $url == undef {
     $graylog_repo_url = $::osfamily ? {
       'debian' => 'https://downloads.graylog.org/repo/debian/',


### PR DESCRIPTION
Just a small fix for an "trailing whitespace" error raised by puppet-lint.