### PR TITLE
Allow puppetlabs-apt < 7.0.0, puppetlabs-stdlib < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,11 +19,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.11.0 < 5.0.0"
+      "version_requirement": ">= 4.11.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.2 < 5.0.0"
+      "version_requirement": ">= 2.2.2 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Fixes #26