### PR TITLE
Problem with /etc/apt/apt.conf.d/01Proxy

### DIFF
--- a/manifests/repository/apt.pp
+++ b/manifests/repository/apt.pp
@@ -42,35 +42,38 @@ class graylog::repository::apt(
   }
 
   if $proxy {
-    file {'/etc/apt/apt.conf.d/01proxy':
+    file {'/etc/apt/apt.conf.d/01_graylog_proxy':
       ensure => present,
     }
-    # Each file_line resource will append http or https proxy info for its specified source into the 01proxy file.
+    # Each file_line resource will append http or https proxy info for its specified source into the 01_graylog_proxy file.
     # If a line already exists for that source, and doesn't match the provided proxy param, that line will be replaced.
     # If a line does not exist for that source, the provided info will be appended.
     $package_sources.each |String $source| {
       file_line { "Acquire::http::proxy::${source}":
-        path    => '/etc/apt/apt.conf.d/01proxy',
+        path    => '/etc/apt/apt.conf.d/01_graylog_proxy',
         match   => "Acquire::http::proxy::${source}",
         line    => "Acquire::http::proxy::${source} \"${proxy}\";",
-        require => File['/etc/apt/apt.conf.d/01proxy'],
+        require => File['/etc/apt/apt.conf.d/01_graylog_proxy'],
         before  => Apt::Source['graylog']
       }
       file_line { "Acquire::https::proxy::${source}":
-        path    => '/etc/apt/apt.conf.d/01proxy',
+        path    => '/etc/apt/apt.conf.d/01_graylog_proxy',
         match   => "Acquire::https::proxy::${source}",
         line    => "Acquire::https::proxy::${source} \"${proxy}\";",
-        require => File['/etc/apt/apt.conf.d/01proxy'],
+        require => File['/etc/apt/apt.conf.d/01_graylog_proxy'],
         before  => Apt::Source['graylog']
       }
     }
   }
   else {
-    # If proxy parameter has not been provided, remove any existing graylog package sources from the 01proxy file (if
+    file {'/etc/apt/apt.conf.d/01_graylog_proxy':
+        ensure => present,
+    }
+    # If proxy parameter has not been provided, remove any existing graylog package sources from the 01_graylog_proxy file (if
     # it exists)
     file_line { 'Remove graylog config from apt proxy file':
       ensure            => absent,
-      path              => '/etc/apt/apt.conf.d/01proxy',
+      path              => '/etc/apt/apt.conf.d/01_graylog_proxy',
       match             => 'graylog',
       match_for_absence => true,
       multiple          => true,


### PR DESCRIPTION
OS: ubuntu 16.04
puppet-agent version: 5.5.10
puppetserver:  5.3.7
Issue: [Apt repo class does not work properly](https://github.com/Graylog2/puppet-graylog/issues/30)
For code
```puppet
class { 'graylog::repository':
  version => '3.0'
}->
class { 'graylog::server':
  package_version => '3.0.0-12',
  config          => {
    'password_secret'       => 'password',
    'root_password_sha2' => '3b18da9f4e1ddd0439e0f76f7414724234091ba1353e09e1e9e42b494c2a052d',
  }
}
```
I get this error:
```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for ubuntu16
Info: Applying configuration version '1558548639'
Error: /Stage[main]/Graylog::Repository::Apt/File_line[Remove graylog config from apt proxy file]: Could not evaluate: No such file or directory @ rb_sysopen - /etc/apt/apt.conf.d/01proxy
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install graylog-server=3.0.0-12' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package graylog-server
Error: /Stage[main]/Graylog::Server/Package[graylog-server]/ensure: change from 'purged' to '3.0.0-12' failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install graylog-server=3.0.0-12' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package graylog-server
```

I fixed this problem