### PR TITLE
Fixed problem: adding graylog's apt source and apt update after install graylog-server

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -4,8 +4,8 @@ class graylog::repository(
   $proxy = undef,
   $release = $graylog::params::repository_release,
 ) inherits graylog::params {
+
   anchor { 'graylog::repository::begin': }
-  anchor { 'graylog::repository::end': }
 
   if $url == undef {
     $graylog_repo_url = $::osfamily ? {
@@ -36,4 +36,5 @@ class graylog::repository(
       fail("${::osfamily} is not supported!")
     }
   }
+  anchor { 'graylog::repository::end': }
 }

--- a/manifests/repository/apt.pp
+++ b/manifests/repository/apt.pp
@@ -12,6 +12,8 @@ class graylog::repository::apt(
     'graylog2-package-repository.s3.amazonaws.com',
   ]
 
+  anchor { 'graylog::repository::apt::begin': }
+
   if !defined(Package[$apt_transport_package]) {
     ensure_packages([$apt_transport_package])
   }
@@ -77,4 +79,11 @@ class graylog::repository::apt(
       before            => Apt::Source['graylog']
     }
   }
+
+  anchor { 'graylog::repository::apt::end': }
+
+  Anchor['graylog::repository::apt::begin']
+  -> Exec['apt_update']
+  -> Anchor['graylog::repository::apt::end']
+  -> Anchor['graylog::repository::end']
 }


### PR DESCRIPTION
OS: Ubuntu 16.04
puppet-agent version: 5.5.10
puppetserver: 5.3.7
Reproduce problem:
```puppet
class { 'graylog::repository':
  version => '3.0'
}->
class { 'graylog::server':
  package_version => '3.0.0-12',
  config          => {
    'password_secret'       => 'password',
    'root_password_sha2' => '3b18da9f4e1ddd0439e0f76f7414724234091ba1353e09e1e9e42b494c2a052d',
  }
}
```
first run puppet agent log:
```
root@ubuntu16:~# puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'development', switching agent to 'development'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for ubuntu16
Info: Applying configuration version '1558559921'
Notice: /Stage[main]/Graylog::Repository::Apt/File[/etc/apt/trusted.gpg.d/graylog-keyring.gpg]/ensure: defined content as '{md5}a2f5c4745035bb3f401c1b0605011761' (corrective)
Info: /Stage[main]/Graylog::Repository::Apt/File[/etc/apt/trusted.gpg.d/graylog-keyring.gpg]: Scheduling refresh of Exec[apt_update]
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install graylog-server=3.0.0-12' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package graylog-server
Error: /Stage[main]/Graylog::Server/Package[graylog-server]/ensure: change from 'purged' to '3.0.0-12' failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install graylog-server=3.0.0-12' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package graylog-server (corrective)
Notice: /Stage[main]/Graylog::Server/File[/etc/graylog/server/server.conf]: Dependency Package[graylog-server] has failures: true
Warning: /Stage[main]/Graylog::Server/File[/etc/graylog/server/server.conf]: Skipping because of failed dependencies
Warning: /Stage[main]/Graylog::Server/Service[graylog-server]: Skipping because of failed dependencies
Warning: /Stage[main]/Graylog::Server/Anchor[graylog::server::end]: Skipping because of failed dependencies
Notice: /Stage[main]/Graylog::Repository::Apt/Apt::Source[graylog]/Apt::Setting[list-graylog]/File[/etc/apt/sources.list.d/graylog.list]/ensure: defined content as '{md5}825c94cb38e29d23849372e86b3f11a2' (corrective)
Info: /Stage[main]/Graylog::Repository::Apt/Apt::Source[graylog]/Apt::Setting[list-graylog]/File[/etc/apt/sources.list.d/graylog.list]: Scheduling refresh of Class[Apt::Update]
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Info: Apt::Source[graylog]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 3 events
Info: Stage[main]: Unscheduling all events on Stage[main]
Notice: Applied catalog in 3.42 seconds
```
Apt update execute after added graylog's apt source =(.
With PR fixed this problem.

