### PR TITLE
Bump apt dependency to 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.2 < 7.0.0"
+      "version_requirement": ">= 2.2.2 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Breaking change for this is a higher version of Puppet. Since this module doesn't nominally restrict puppet versions, that's a non-issue; anyone checking for dependencies should run into this by themselves when considering versions.