### PR TITLE
Do not manage the repository on RedHat when manage_repo is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1 (2023-06-23)
+- Do not manage the repository on RedHat when manage_repo is set to false
+  - **Attention:** This flag has no effect on debian OS
 
 ## 1.0.0 (2021-10-25)
 - Add ability to update Java Heapsize. ([#47](https://github.com/Graylog2/puppet-graylog/issues/47))

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ elasticsearch::instance { 'graylog':
 }
 
 class { 'graylog::repository':
-  version => '4.2'
+  version     => '4.2',
+  manage_repo => true,
 }->
 class { 'graylog::server':
   package_version => '4.2.0-3',
@@ -184,6 +185,11 @@ version.
 It defaults to `$graylog::params::major_version`.
 
 Example: `version => '4.2'`
+
+##### `manage_repo`
+
+This setting indicates if the Graylog package repositories are managed automatically.
+This is only valid for RedHat.
 
 ##### `url`
 

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -1,8 +1,9 @@
-class graylog::repository(
-  $version = $graylog::params::major_version,
-  $url     = undef,
-  $proxy = undef,
-  $release = $graylog::params::repository_release,
+class graylog::repository (
+  $version     = $graylog::params::major_version,
+  $manage_repo = true,
+  $url         = undef,
+  $proxy       = undef,
+  $release     = $graylog::params::repository_release,
 ) inherits graylog::params {
 
   anchor { 'graylog::repository::begin': }
@@ -12,7 +13,7 @@ class graylog::repository(
       'debian' => 'https://downloads.graylog.org/repo/debian/',
       'redhat' => "https://downloads.graylog.org/repo/el/${release}/${version}/\$basearch/",
       default  => fail("${::osfamily} is not supported!"),
-      }
+    }
   } else {
     $graylog_repo_url = $url
   }
@@ -27,9 +28,11 @@ class graylog::repository(
       }
     }
     'redhat': {
-      class { 'graylog::repository::yum':
-        url   => $graylog_repo_url,
-        proxy => $proxy,
+      if $manage_repo != false {
+        class { 'graylog::repository::yum':
+          url   => $graylog_repo_url,
+          proxy => $proxy,
+        }
       }
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-graylog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Graylog, Inc.",
   "summary": "Install and configure a Graylog system",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Notes for Reviewers

- It is important to be able to manage Graylog the repositories, especially for RedHat systems having their own satellite.
