### PR TITLE
Replaced legacy facts

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -7,16 +7,16 @@ class graylog::repository (
   anchor { 'graylog::repository::begin': }
 
   if $url == undef {
-    $graylog_repo_url = $::osfamily ? {
+    $graylog_repo_url = $facts['os']['family'] ? {
       'debian' => 'https://downloads.graylog.org/repo/debian/',
       'redhat' => "https://downloads.graylog.org/repo/el/${release}/${version}/\$basearch/",
-      default  => fail("${::osfamily} is not supported!"),
-      }
+      default  => fail("${facts['os']['family']} is not supported!"),
+    }
   } else {
     $graylog_repo_url = $url
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'debian': {
       class { 'graylog::repository::apt':
         url     => $graylog_repo_url,
@@ -32,7 +32,7 @@ class graylog::repository (
       }
     }
     default: {
-      fail("${::osfamily} is not supported!")
+      fail("${facts['os']['family']} is not supported!")
     }
   }
   anchor { 'graylog::repository::end': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,7 +50,7 @@ class graylog::server (
     content => template("${module_name}/server/graylog.conf.erb"),
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'debian': {
       file { '/etc/default/graylog-server':
         ensure  => file,
@@ -80,7 +80,7 @@ class graylog::server (
       }
     }
     default: {
-      fail("${::osfamily} is not supported!")
+      fail("${facts['os']['family']} is not supported!")
     }
   }
 


### PR DESCRIPTION
The `$::osfamily` legacy fact no longer works on Puppet 8. This replaces it with `$facts['os']['family']`.