### PR TITLE
Mark config file as sensitive

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -47,7 +47,7 @@ class graylog::server (
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    content => template("${module_name}/server/graylog.conf.erb"),
+    content => Sensitive(template("${module_name}/server/graylog.conf.erb")),
   }
 
   case $::osfamily {


### PR DESCRIPTION
This file contains passwords and other secrets, treating it as sensitive prevents Puppet from showing the diff and thus leaking the password in reports.