### PR TITLE
Removing legacy facts

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -7,16 +7,16 @@ class graylog::repository (
   anchor { 'graylog::repository::begin': }
 
   if $url == undef {
-    $graylog_repo_url = $::osfamily ? {
+    $graylog_repo_url = $facts['os']['family'] ? {
       'debian' => 'https://downloads.graylog.org/repo/debian/',
       'redhat' => "https://downloads.graylog.org/repo/el/${release}/${version}/\$basearch/",
-      default  => fail("${::osfamily} is not supported!"),
+      default  => fail("${facts['os']['family']} is not supported!"),
       }
   } else {
     $graylog_repo_url = $url
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'debian': {
       class { 'graylog::repository::apt':
         url     => $graylog_repo_url,
@@ -32,7 +32,7 @@ class graylog::repository (
       }
     }
     default: {
-      fail("${::osfamily} is not supported!")
+      fail("${facts['os']['family']} is not supported!")
     }
   }
   anchor { 'graylog::repository::end': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,7 +50,7 @@ class graylog::server (
     content => template("${module_name}/server/graylog.conf.erb"),
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'debian': {
       file { '/etc/default/graylog-server':
         ensure  => file,
@@ -80,7 +80,7 @@ class graylog::server (
       }
     }
     default: {
-      fail("${::osfamily} is not supported!")
+      fail("${facts['os']['family']} is not supported!")
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 6.21.0 < 9.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
The modern facts were introduced in Puppet 4.0 and the so-called legacy facts were deprecated in Puppet 6.0 which was released in 2018. Given that, this should be a relatively safe change.

I know there is an identical PR, but it has been waiting for the contributor to sign the CLA for many months. I need this fixed.

This fixes #61 

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

