### PR TITLE
65/Setting puppetlabs/apt max version to 11.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.2 < 9.1.0"
+      "version_requirement": ">= 2.2.2 < 11.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I have tested this on Ubuntu, Debian, Alma, and Rocky and there are no issues.

This fixes #65 

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

